### PR TITLE
Allow sizes to pass through to page res

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,10 @@ module.exports = (Root, _options = {}) => {
   })
 
   const pageres = new Pageres(opts)
-
+  const sizes = opts.sizes === undefined ? [`${opts.width}x${opts.height}`] : opts.sizes;
   const result = outDir
     ? pageres
-      .src(data, [`${opts.width}x${opts.height}`])
+      .src(data, sizes)
       .dest(outDir)
       .run()
     : pageres

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = (Root, _options = {}) => {
   })
 
   const pageres = new Pageres(opts)
+
   const sizes = opts.sizes === undefined ? [`${opts.width}x${opts.height}`] : opts.sizes;
   const result = outDir
     ? pageres
@@ -64,7 +65,7 @@ module.exports = (Root, _options = {}) => {
       .dest(outDir)
       .run()
     : pageres
-      .src(data, [`${opts.width}x${opts.height}`])
+      .src(data, sizes)
       .run()
 
   result.then(streams => {


### PR DESCRIPTION
Allow user to pass in an array of target sizes to insert into the src of pageres.

```
const options = {
  props: {
    title: 'hello'
  },
  sizes: ['480x320', '1024x768', 'iphone 5s']
}
```