### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const options = {
   }
 }
 
-const result = repng(Comp, options)
+const result = repng(Component, options)
 
 result.then(streams => {
   console.log('rendered component')


### PR DESCRIPTION
Currently imports as `Component` and call as `Comp` on repng.